### PR TITLE
Bumping up Chrome version to 48 to run on Sauce Labs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ before_script:
 script:
   - node --version
   - gulp lint
+  - webdriver-manager update
   - gulp tests:integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,6 @@ before_script:
 script:
   - node --version
   - gulp lint
+  - webdriver-manager clean
   - webdriver-manager update
   - gulp tests:integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,5 @@ before_script:
 script:
   - node --version
   - gulp lint
-  - webdriver-manager clean
   - webdriver-manager update
   - gulp tests:integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,4 @@ before_script:
 script:
   - node --version
   - gulp lint
-  - webdriver-manager update
   - gulp tests:integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV NODE_VERSION 4.2.3
 RUN n $NODE_VERSION
 
 RUN npm install -g protractor gulp && \
+    webdriver-manager clean && \
     webdriver-manager update && \
     apt-get update && apt-get install -y xvfb wget openjdk-7-jre git && \
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ENV NODE_VERSION 4.2.3
 RUN n $NODE_VERSION
 
 RUN npm install -g protractor gulp && \
-    webdriver-manager clean && \
     webdriver-manager update && \
     apt-get update && apt-get install -y xvfb wget openjdk-7-jre git && \
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var protractor = require('gulp-protractor').protractor;
 var eslint = require('gulp-eslint');
+var webdriverUpdate = require('gulp-protractor').webdriver_update;
 var SauceTunnel = require('sauce-tunnel');
 var tunnel;
 var isTunnelCreated;
@@ -78,7 +79,8 @@ gulp.task('tests:sauce:end', function (done) {
     });
 });
 
-gulp.task('tests:integration', ['tests:sauce:start'], function () {
+gulp.task('tests:webdriver', webdriverUpdate);
+gulp.task('tests:integration', ['tests:webdriver', 'tests:sauce:start'], function () {
     if (process.env.CI && !isTunnelCreated) {
         // force the process to exit with error code if couldn't create the tunnel
         process.exit(1);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var protractor = require('gulp-protractor').protractor;
 var eslint = require('gulp-eslint');
-var webdriverUpdate = require('gulp-protractor').webdriver_update;
 var SauceTunnel = require('sauce-tunnel');
 var tunnel;
 var isTunnelCreated;
@@ -79,8 +78,7 @@ gulp.task('tests:sauce:end', function (done) {
     });
 });
 
-gulp.task('tests:webdriver', webdriverUpdate);
-gulp.task('tests:integration', ['tests:webdriver', 'tests:sauce:start'], function () {
+gulp.task('tests:integration', ['tests:sauce:start'], function () {
     if (process.env.CI && !isTunnelCreated) {
         // force the process to exit with error code if couldn't create the tunnel
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "jasmine-core": "2.4.1",
         "jasmine-spec-reporter": "2.5.0",
         "jasmine-fail-fast": "2.0.0",
-        "protractor": "3.3.0",
+        "protractor": "4.0.2",
         "sauce-tunnel": "2.5.0"
     }
 }

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['chrome 50'] })
+    sauceLabsBrowsers: b2s({ browsers: ['chrome 51'] })
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['chrome 42'] })
+    sauceLabsBrowsers: b2s({ browsers: ['chrome 51'] })
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['last 2 Chrome versions'] })
+    sauceLabsBrowsers: b2s({ browsers: ['chrome 48'] })
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['chrome 51'] })
+    sauceLabsBrowsers: b2s({ browsers: ['last 2 Chrome versions'] })
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['chrome 51'] })
+    sauceLabsBrowsers: b2s({ browsers: ['last 1 Chrome version'] })
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['last 1 Chrome version'] })
+    sauceLabsBrowsers: b2s({ browsers: ['chrome 48'] })
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -17,5 +17,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s({ browsers: ['chrome 48'] })
+    sauceLabsBrowsers: b2s({ browsers: ['chrome 50'] })
 };


### PR DESCRIPTION
**This pull request bumps up Chrome version to 48 to run on Sauce Labs**

Also:
- bumped up protractor to 4.0.2
- moved `webdriver-manager update` to .travis.yml to download proper chromedriver 2.22
